### PR TITLE
Fix GetWindowsAccentColor Parsing

### DIFF
--- a/DarkModeCS.cs
+++ b/DarkModeCS.cs
@@ -595,7 +595,7 @@ namespace BlueMystic
 			{
 				var color = colors.ColorizationColor;
 
-				var colorValue = long.Parse(color.ToString(), System.Globalization.NumberStyles.HexNumber);
+				var colorValue = long.Parse(color.ToString("X"), System.Globalization.NumberStyles.HexNumber);
 
 				var transparency = (colorValue & 0xFF000000) >> 24;
 				var red = (colorValue & 0x00FF0000) >> 16;

--- a/Example/DarkModeForms/DarkModeCS.cs
+++ b/Example/DarkModeForms/DarkModeCS.cs
@@ -595,7 +595,7 @@ namespace BlueMystic
 			{
 				var color = colors.ColorizationColor;
 
-				var colorValue = long.Parse(color.ToString(), System.Globalization.NumberStyles.HexNumber);
+				var colorValue = long.Parse(color.ToString("X"), System.Globalization.NumberStyles.HexNumber);
 
 				var transparency = (colorValue & 0xFF000000) >> 24;
 				var red = (colorValue & 0x00FF0000) >> 16;


### PR DESCRIPTION
Hello, I have noticed that this method was not returning correct Windows Accent color and after this fix it does now.

Source: https://stackoverflow.com/a/17808712 (`BgraToColor`)