### PR TITLE
ToolStrip made movable; bkcolor of ToolStripPanel and MdiClient

### DIFF
--- a/SourceFiles/DarkModeCS.cs
+++ b/SourceFiles/DarkModeCS.cs
@@ -4,6 +4,7 @@ using System;
 using System.ComponentModel;
 using System.Drawing.Drawing2D;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
@@ -521,6 +522,30 @@ namespace DarkModeForms
 				grid.BorderStyle = BorderStyle.FixedSingle;
 				grid.BackgroundColor = OScolors.Control;
 				grid.GridColor = OScolors.Control;
+
+				//paint the bottom right corner where the scrollbars meet
+				grid.Paint += (object sender, PaintEventArgs e) =>
+				{
+					DataGridView dgv = sender as DataGridView;
+
+					//get the value of dgv.HorizontalScrollBar protected property
+					HScrollBar hs = (HScrollBar)typeof(DataGridView).GetProperty("HorizontalScrollBar", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(dgv);
+					if (hs.Visible)
+					{
+						//get the value of dgv.VerticalScrollBar protected property
+						VScrollBar vs = (VScrollBar)typeof(DataGridView).GetProperty("VerticalScrollBar", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(dgv);
+
+						if (vs.Visible)
+						{
+							//only when both the scrollbars are visible, do the actual painting
+							Brush brush = new SolidBrush(OScolors.Surface); //or even darker...
+							var w = vs.Size.Width;//System.Windows.Forms.SystemInformation.VerticalScrollBarWidth;
+							var h = hs.Size.Height;//System.Windows.Forms.SystemInformation.HorizontalScrollBarHeight;
+							e.Graphics.FillRectangle(brush, e.ClipRectangle.X + e.ClipRectangle.Width - w - 1,
+					  e.ClipRectangle.Y + e.ClipRectangle.Height - h - 1, w, h);
+						}
+					}
+				};
 
 				grid.DefaultCellStyle.BackColor = OScolors.Surface;
 				grid.DefaultCellStyle.ForeColor = OScolors.TextActive;

--- a/SourceFiles/DarkModeCS.cs
+++ b/SourceFiles/DarkModeCS.cs
@@ -218,13 +218,13 @@ namespace DarkModeForms
 
 		#region Static Local Members
 
-	    /// <summary>
-	    /// prevents applying a theme multiple times to the same control
-	    /// without this, it happens at least is some MDI forms
-	    /// currently, only Key is being used, the Value is not.
-	    /// Using ConditionalWeakTable because I found no suitable ISet<Control> implementation
-	    /// </summary>
-	    private static readonly ConditionalWeakTable<Control, object> ControlsProcessed = new ConditionalWeakTable<Control, object>();		
+		/// <summary>
+		/// prevents applying a theme multiple times to the same control
+		/// without this, it happens at least is some MDI forms
+		/// currently, only Key is being used, the Value is not.
+		/// Using ConditionalWeakTable because I found no suitable ISet<Control> implementation
+		/// </summary>
+		private static readonly ConditionalWeakTable<Control, object> ControlsProcessed = new ConditionalWeakTable<Control, object>();
 
 		#endregion
 
@@ -290,7 +290,7 @@ namespace DarkModeForms
 			//without this, it happens at least is some MDI forms
 			if (ControlsProcessed.TryGetValue(control, out object _)) return;
 			ControlsProcessed.Add(control, null);
-      
+
 			BorderStyle BStyle = (IsDarkMode ? BorderStyle.FixedSingle : BorderStyle.Fixed3D);
 			FlatStyle FStyle = (IsDarkMode ? FlatStyle.Flat : FlatStyle.Standard);
 
@@ -491,9 +491,20 @@ namespace DarkModeForms
 			}
 			if (control is ToolStrip toolBar)
 			{
-				toolBar.GripStyle = ToolStripGripStyle.Hidden;
+				//commented out because it would just freeze the toolstrips with no obvious benefit:
+				//toolBar.GripStyle = ToolStripGripStyle.Hidden;
 				toolBar.RenderMode = ToolStripRenderMode.Professional;
 				toolBar.Renderer = new MyRenderer(new CustomColorTable(OScolors), ColorizeIcons) { MyColors = OScolors };
+			}
+			if (control is ToolStripPanel tsp)
+			{
+				//empty area around ToolStrip
+				tsp.BackColor = OScolors.Surface;
+			}
+			if (control is MdiClient mdiClient)
+			{
+				//empty area of MDI container window
+				mdiClient.BackColor = OScolors.Surface;
 			}
 			if (control is ContextMenuStrip cMenu)
 			{
@@ -577,7 +588,7 @@ namespace DarkModeForms
 		/// <summary>
 		/// handle hierarchical context menus (otherwise, only the root level gets themed)
 		/// </summary>
-		private void Tsdd_Opening (object sender, CancelEventArgs e)
+		private void Tsdd_Opening(object sender, CancelEventArgs e)
 		{
 			ToolStripDropDown tsdd = sender as ToolStripDropDown;
 			if (tsdd == null) return; //should not occur
@@ -591,7 +602,7 @@ namespace DarkModeForms
 		/// <summary>
 		/// handle hierarchical context menus (otherwise, only the root level gets themed)
 		/// </summary>
-		private void Tsmi_DropDownOpening (object sender, EventArgs e)
+		private void Tsmi_DropDownOpening(object sender, EventArgs e)
 		{
 			ToolStripMenuItem tsmi = sender as ToolStripMenuItem;
 			if (tsmi == null) return; //should not occur
@@ -600,11 +611,6 @@ namespace DarkModeForms
 
 			//once processed, remove itself to prevent multiple executions (when user leaves and reenters the sub-menu)
 			tsmi.DropDownOpening -= Tsmi_DropDownOpening;
-		}
-
-		private void Tree_DrawNode(object sender, DrawTreeNodeEventArgs e)
-		{
-			throw new NotImplementedException();
 		}
 
 		/// <summary>Returns Windows Color Mode for Applications.


### PR DESCRIPTION
re-enabling ToolStrip to be moved (as discussed before);

improving background color of ToolStripPanel and MdiClient (they were white before this fix)

![before](https://github.com/BlueMystical/Dark-Mode-Forms/assets/168674258/b1bb646e-aeb8-437c-a196-95e5d056f37c)
![after_surface](https://github.com/BlueMystical/Dark-Mode-Forms/assets/168674258/7c5b3319-2519-4a46-9173-d68a8f7bbe26)
