### PR TITLE
Fix MessageBox icons and Ceate a reload of MessageBox that takes MsgIcon instead of MessageBoxIcon

### DIFF
--- a/SourceFiles/Messenger.cs
+++ b/SourceFiles/Messenger.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using static DarkModeForms.KeyValue;
+using Timer = System.Windows.Forms.Timer;
 
 namespace DarkModeForms
 {

--- a/SourceFiles/Messenger.cs
+++ b/SourceFiles/Messenger.cs
@@ -78,6 +78,12 @@ namespace DarkModeForms
 			return MessageBox(Message, title, Icon, buttons, pIsDarkMode);
 		}
 
+		public static DialogResult MessageBox(string Message, string title, MessageBoxButtons buttons = MessageBoxButtons.OK,
+											  MsgIcon icon = MsgIcon.None, bool pIsDarkMode = true)
+		{
+			return MessageBox(Message, title, icon, buttons, pIsDarkMode);
+		}
+
 		/// <summary>Displays a message window, also known as a dialog box, which presents a message to the user.</summary>
 		/// <param name="Message">The text to display in the message box.</param>
 		/// <param name="title">The text to display in the title bar of the message box.</param>

--- a/SourceFiles/Messenger.cs
+++ b/SourceFiles/Messenger.cs
@@ -67,9 +67,9 @@ namespace DarkModeForms
 			switch (icon)
 			{
 				case MessageBoxIcon.Information: Icon = MsgIcon.Info; break;
-				case MessageBoxIcon.Exclamation: Icon = MsgIcon.Success; break;
+				case MessageBoxIcon.Exclamation: Icon = MsgIcon.Warning; break;
 				case MessageBoxIcon.Question: Icon = MsgIcon.Question; break;
-				case MessageBoxIcon.Error: Icon = MsgIcon.Cancel; break;
+				case MessageBoxIcon.Error: Icon = MsgIcon.Error; break;
 				case MessageBoxIcon.None:
 				default:
 					break;


### PR DESCRIPTION
1. Fix MessageBox icons
2. Ceate a reload of MessageBox that takes MsgIcon instead of MessageBoxIcon

![Snipaste_2024-10-10_14-54-43](https://github.com/user-attachments/assets/93a95311-74f2-4760-84f7-fe5f912b81a4)
