### PR TITLE
Leave DataGridView's ColumnHeadersHeight untouched

### DIFF
--- a/SourceFiles/DarkModeCS.cs
+++ b/SourceFiles/DarkModeCS.cs
@@ -828,7 +828,6 @@ namespace DarkModeForms
 				grid.ColumnHeadersDefaultCellStyle.ForeColor = OScolors.TextActive;
 				grid.ColumnHeadersDefaultCellStyle.SelectionBackColor = OScolors.Surface;
 				grid.ColumnHeadersBorderStyle = DataGridViewHeaderBorderStyle.Single;
-				grid.ColumnHeadersHeight = 140;
 
 				grid.RowHeadersDefaultCellStyle.BackColor = OScolors.Surface;
 				grid.RowHeadersDefaultCellStyle.ForeColor = OScolors.TextActive;


### PR DESCRIPTION
Why manually setting DataGridView's `ColumnHeadersHeight` to be `140`? It breaks the default UI layout or the one user defined.

![image](https://github.com/user-attachments/assets/0c73e7d9-987c-466e-96f9-fd9c53e7786e)
