### PR TITLE
commented out Debug.WriteLine() calls

### DIFF
--- a/SourceFiles/DarkModeCS.cs
+++ b/SourceFiles/DarkModeCS.cs
@@ -359,7 +359,7 @@ namespace DarkModeForms
 		private IntPtr CustomWndProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam)
 		{
 			// Handle the WM_THEMECHANGED message
-			Debug.WriteLine($"Message Code: {msg}");
+			// Debug.WriteLine($"Message Code: {msg}"); // <-- should not be enabled in production as it slows everything down!
 			if (msg == WM_SETTINGSCHANGE && !applyingTheme)
 			{
 				applyingTheme = true; // Set the flag to prevent recursion

--- a/SourceFiles/DarkModeCS.cs
+++ b/SourceFiles/DarkModeCS.cs
@@ -868,7 +868,7 @@ namespace DarkModeForms
 			}
 
 
-			Debug.Print(string.Format("{0}: {1}", control.Name, control.GetType().Name));
+			//Debug.Print(string.Format("{0}: {1}", control.Name, control.GetType().Name));
 
 			if (control.ContextMenuStrip != null)
 				ThemeControl(control.ContextMenuStrip);

--- a/SourceFiles/Messenger.cs
+++ b/SourceFiles/Messenger.cs
@@ -57,7 +57,7 @@ namespace DarkModeForms
 			string Message, string title, MessageBoxButtons buttons = MessageBoxButtons.OK,
 			MessageBoxIcon icon = MessageBoxIcon.Information, bool pIsDarkMode = true)
 		{
-			Debug.WriteLine(icon.ToString());
+			//Debug.WriteLine(icon.ToString());
 
 			MsgIcon Icon = MsgIcon.None;
 


### PR DESCRIPTION
Hi, I noticed that there are `Debug.WriteLine()` calls even in the production (numbered) release.
Not only do they mess up with my debugging, but worse, the one found in `private IntPtr CustomWndProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam)`  substantially slows everything down whenever there is a large number of UI objects created.

So I commented them out.