### PR TITLE
Fix for ApplyTheme(DisplayMode)

### DIFF
--- a/SourceFiles/DarkModeCS.cs
+++ b/SourceFiles/DarkModeCS.cs
@@ -444,6 +444,9 @@ namespace DarkModeForms
 		}
 		public void ApplyTheme(DisplayMode pColorMode)
 		{
+			if (ColorMode == pColorMode) return;
+
+			ColorMode = pColorMode;
 			_IsDarkMode = isDarkMode(); //<- Gets the current color mode from Windows
 			if (ColorMode != DisplayMode.SystemDefault)
 			{


### PR DESCRIPTION
Given DisplayMode wasnt used at all.
I Added a return if (ColorMode == pColorMode) to prevent potential flickering if its called frequently, but this would be a potential issue if the windows-darkmode-setting changes while the software is running ... 